### PR TITLE
feat: set up cross-package CSS import from `tailwind-config` to `ui`

### DIFF
--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -2,6 +2,9 @@
   "name": "@rime-ui/tailwind-config",
   "version": "1.0.0",
   "description": "",
+  "exports": {
+    "./shared-styles.css": "./shared-styles.css"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/ui/globals.css
+++ b/packages/ui/globals.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@import "@rime-ui/tailwind-config/shared-styles.css";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
     },
     "devDependencies": {
         "@chromatic-com/storybook": "^5.0.0",
+        "@rime-ui/tailwind-config": "workspace:*",
         "@rime-ui/eslint-config": "workspace:*",
         "@rime-ui/typescript-config": "workspace:*",
         "@storybook/addon-a11y": "^10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@rime-ui/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@rime-ui/tailwind-config':
+        specifier: workspace:*
+        version: link:../tailwind-config
       '@rime-ui/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config


### PR DESCRIPTION
Enables cross-package CSS imports by:
- Exporting `shared-styles.css` from `tailwind-config` package
- Adding `tailwind-config` as workspace dependency in `ui`
- Importing shared styles in `ui/globals.css`