### PR TITLE
Add `createSafeContext` hook

### DIFF
--- a/packages/ui/src/hooks/create-safe-context/create-safe-context.tsx
+++ b/packages/ui/src/hooks/create-safe-context/create-safe-context.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+/**
+ * Creates a type-safe React context with runtime safety checks.
+ * 
+ * @template ContextValue - The type of value stored in the context
+ * @param errorMessage - Error message thrown when context is used outside Provider
+ * @returns Object containing Provider component and useSafeContext hook
+ */
+export function createSafeContext<ContextValue>(errorMessage: string) {
+    const Context = React.createContext<ContextValue | null>(null);
+  
+    function useSafeContext() {
+      const ctx = React.useContext(Context);
+  
+      if (ctx === null) {
+        throw new Error(errorMessage);
+      }
+  
+      return ctx;
+    };
+  
+
+    function Provider(props: { value: ContextValue; children: React.ReactNode }) {
+      return <Context.Provider value={props.value}>{props.children}</Context.Provider>
+    }
+
+  
+    return {Provider, useSafeContext} as const;
+  }

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { createSafeContext } from "./create-safe-context/create-safe-context";
+


### PR DESCRIPTION
### Summary
Adds a reusable utility hook for creating type-safe React contexts with runtime safety checks.

### Changes
- **New hook**: `createSafeContext` in `packages/ui/src/hooks/create-safe-context/`
- **Export**: Added to `packages/ui/src/hooks/index.ts`

### Usage
```ts
const { Provider, useSafeContext } = createSafeContext<ContextValue>(
  "Component must be wrapped in <Provider>"
);
```