### PR TITLE
chore(ui): update TypeScript config and React imports

### DIFF
--- a/packages/ui/src/components/button/button.tsx
+++ b/packages/ui/src/components/button/button.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type React from 'react'
+import React from 'react'
 import { tv, type VariantProps } from 'tailwind-variants'
 
 const button = tv({

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@rime-ui/typescript-config/react-library.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "outDir": "dist"
   },
   "include": ["src"],


### PR DESCRIPTION
- Change JSX transform from 'react' to 'react-jsx' in tsconfig.json for modern React 17+ JSX transform
- Remove type-only import of React in button component to use regular import

Work done by: @Mahmoud-walid